### PR TITLE
W-OA-9c 1.2.	グループによるACL機能

### DIFF
--- a/docs/spec/_book/ADMIN_3_1.md
+++ b/docs/spec/_book/ADMIN_3_1.md
@@ -177,7 +177,7 @@
 
               - ロール権限に設定できるグループIDのフォーマット（プレフィックス、システム管理者用グループID）は、設定値 WEKO\_ACCOUNTS\_GAKUNIN\_GROUP\_PATTERN\_DICT を変更することで、フォーマットを変更できる。
 
-         - 上記以外のグループIDの場合はグループ権限として表示され、閲覧権限を変更設できる。
+         - 上記以外のグループIDの場合はグループ権限として表示され、閲覧権限を変更できる。
 
               - ただし、学認mAPのグループ情報は内部的には全てロールとして扱われる。
 
@@ -338,8 +338,7 @@
 
   - GakuNin mAPから連携されたグループ情報の閲覧権限初期値を設定する。（Trueの場合、閲覧権限ありとして初期値を設定する。）
     
-      [](TOOD: config.pyとinstance.cfgのパスを決める。)
-      - パス：<https://github.com/RCOSDP/weko/blob/v0.9.22/modules/weko-search-ui/weko_search_ui/config.py#L87>
+      - パス：<https://github.com/RCOSDP/weko/blob/v1.1.0/modules/weko-index-tree/weko_index_tree/config.py#L96>
     
       - 設定キー：WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_BROWSING\_PERMISSION
     
@@ -349,8 +348,7 @@
 
   - GakuNin mAPから連携されたグループ情報の投稿権限初期値を設定する。（Trueの場合、投稿権限ありとして初期値を設定する。）
     
-      [](TOOD: config.pyとinstance.cfgのパスを決める。)
-      - パス：<https://github.com/RCOSDP/weko/blob/v0.9.22/modules/weko-search-ui/weko_search_ui/config.py#L87>
+      - パス：<https://github.com/RCOSDP/weko/blob/v1.1.0/modules/weko-index-tree/weko_index_tree/config.py#L99>
     
       - 設定キー：WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_CONTRIBUTE\_PERMISSION
     

--- a/docs/spec/_book/ADMIN_3_1.md
+++ b/docs/spec/_book/ADMIN_3_1.md
@@ -640,7 +640,7 @@
 <td><blockquote>
 <p>2025/01/30</p>
 </blockquote></td>
-<td>7733de131da9ad59ab591b2df1c70ddefcfcad98</td>
+<td>3530eae9075af6afc57b777d8c3137f038523610</td>
 <td>学認mAP連携対応</td>
 </tr>
 </tbody>

--- a/docs/spec/_book/ADMIN_3_1.md
+++ b/docs/spec/_book/ADMIN_3_1.md
@@ -165,6 +165,24 @@
         
           - 「子インデックスのグループ権限にも再帰的に反映させる」（Set the base authorities of child indexes recursively）チェックボックスにチェックを入れることで、所属する子インデックスと子孫インデックスすべてにグループの設定が再帰的に設定される。
 
+      - 学認mAP連携機能が有効な場合、閲覧権限の設定に学認mAPのグループ情報を利用できる。
+
+         - グループIDのフォーマットが「jc\_<institution_fqdn>\_roles\_<role_keyword>」に従っている学認グループは、ロール権限として表示され閲覧権限を変更できる。
+
+              - <institution_fqdn>には機関のFQDNから".","-"を"_"に置換した値が設定される。
+
+                  - 例: abc-u.ac.jp → abc_u_ac_jp
+
+              - 例外的に「jc_roles_sysadm」もロール権限として表示され閲覧権限を変更できる。
+
+              - ロール権限に設定できるグループIDのフォーマット（プレフィックス、システム管理者用グループID）は、設定値 WEKO\_ACCOUNTS\_GAKUNIN\_GROUP\_PATTERN\_DICT を変更することで、フォーマットを変更できる。
+
+         - 上記以外のグループIDの場合はグループ権限として表示され、閲覧権限を変更設できる。
+
+              - ただし、学認mAPのグループ情報は内部的には全てロールとして扱われる。
+
+         - 学認mAP連携機能でGakuNin mAPのグループ情報がWEKO3に追加された際、設定するmAPグループの閲覧権限のデフォルト値は、WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_BROWSING\_PERMISSIONの真偽値から権限有無を決定する。
+
   - 「投稿権限」（Deposit Privilege）
     
       - ロール権限の設定には、  
@@ -192,6 +210,24 @@
           - 「グループ権限あり」（Group Authorized）は、デフォルトとして、登録されているグループが表示される。
         
           - 「子インデックスのグループ権限にも再帰的に反映させる」（Set the base authorities of child indexes recursively）チェックボックスにチェックを入れることで、所属する子インデックスと子孫インデックスすべてにグループの設定が再帰的に設定される。
+
+      - 学認mAP連携機能が有効な場合、投稿権限の設定に学認mAPのグループ情報を利用できる。
+
+         - グループIDのフォーマットが「jc\_<institution_fqdn>\_roles\_<role_keyword>」に従っている学認グループは、ロール権限として表示され投稿権限を変更できる。
+
+              - <institution_fqdn>には機関のFQDNから".","-"を"_"に置換した値が設定される。
+
+                  - 例: abc-u.ac.jp → abc_u_ac_jp
+
+              - 例外的に「jc_roles_sysadm」もロール権限として表示され投稿権限を変更できる。
+
+              - ロール権限に設定できるグループIDのフォーマット（プレフィックス、システム管理者グループID）は、設定値 WEKO\_ACCOUNTS\_GAKUNIN\_GROUP\_PATTERN\_DICT を変更することで、フォーマットを変更できる。
+
+         - ロール権限として利用できない学認グループは、すべてグループ権限として表示され、投稿権限を変更できる。
+
+              - ただし、学認mAPのグループ情報は内部的には全てロールとして扱われる。
+
+         - 学認mAP連携機能でGakuNin mAPのグループ情報がWEKO3に追加された際、設定するmAPグループの投稿権限のデフォルト値は、WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_CONTRIBUTE\_PERMISSIONの真偽値から権限有無を決定する。
 
   - 「表示形式(検索結果)」（Display Format(Search Results)）  
     検索結果の表示形式を選択する。
@@ -297,6 +333,31 @@
       - インデックスのキャッシュはRedisサーバに以下キー名でインデックス保存時に作成される。
         
           - index\_tree\_view\_" + os.environ.get('INVENIO\_WEB\_HOST\_NAME') + "\_" + lang
+
+5\. 設定
+
+  - GakuNin mAPから連携されたグループ情報の閲覧権限初期値を設定する。（Trueの場合、閲覧権限ありとして初期値を設定する。）
+    
+      [](TOOD: config.pyとinstance.cfgのパスを決める。)
+      - パス：<https://github.com/RCOSDP/weko/blob/v0.9.22/modules/weko-search-ui/weko_search_ui/config.py#L87>
+    
+      - 設定キー：WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_BROWSING\_PERMISSION
+    
+      - 現在の設定値：
+
+> WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_BROWSING\_PERMISSION = False
+
+  - GakuNin mAPから連携されたグループ情報の投稿権限初期値を設定する。（Trueの場合、投稿権限ありとして初期値を設定する。）
+    
+      [](TOOD: config.pyとinstance.cfgのパスを決める。)
+      - パス：<https://github.com/RCOSDP/weko/blob/v0.9.22/modules/weko-search-ui/weko_search_ui/config.py#L87>
+    
+      - 設定キー：WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_CONTRIBUTE\_PERMISSION
+    
+      - 現在の設定値：
+
+> WEKO\_INDEXTREE\_GAKUNIN\_GROUP\_DEFAULT\_CONTRIBUTE\_PERMISSION = False
+
 
 <table>
 <thead>
@@ -574,6 +635,13 @@
 </blockquote></td>
 <td>7733de131da9ad59ab591b2df1c70ddefcfcad98</td>
 <td>v1.0.7対応</td>
+</tr>
+<tr class="odd">
+<td><blockquote>
+<p>2025/01/30</p>
+</blockquote></td>
+<td>7733de131da9ad59ab591b2df1c70ddefcfcad98</td>
+<td>学認mAP連携対応</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
学認mAP連携によるJAIRO Cloudグループ機能の実装

1.  mAPグループがインデックスの閲覧権限、投稿権限のグループの項目（図 3）で、権限の有り、無しを設定する
    - 内部的にはRoleとして処理することを明記
2. mAPグループのデフォルト設定を閲覧権限、投稿権限それぞれで設定できる
